### PR TITLE
Fix voxel buffer clearing every frame

### DIFF
--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -48,10 +48,10 @@ void main() {
         renderState.sunDirection = normalize(renderState.sunPosition);
     }
 
-    // Only clear buffers right after starting the path tracer (F1 pressed)
-    renderState.clear = (renderState.frame <= 1);
+    // Always clear voxel structures before voxelization to ensure newly loaded chunks are captured
+    renderState.clear = true;
 
-    if (renderState.frame <= 1) {
+    {
         quadBuffer.aabb = scene_aabb(10000, 10000, 10000, -10000, -10000, -10000);
         quadBuffer.count = 0u;
 

--- a/shaders/program/voxelization/prepare/clear_structures.csh
+++ b/shaders/program/voxelization/prepare/clear_structures.csh
@@ -8,10 +8,7 @@ layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(65535, 1, 1);
 
 void main() {
-    // Only clear voxels on the frame F1 was pressed to start tracing
-    if (renderState.frame > 1) {
-        return;
-    }
+    // Clear voxel structures every frame so newly loaded chunks do not keep stale data
 
     for (uint id = gl_GlobalInvocationID.x * 8u; id < 512u * 386u * 512u; id += 65535u * 8u) {
         for (int i = 0; i < 8; i++) {

--- a/shaders/program/voxelization/shadow.gsh
+++ b/shaders/program/voxelization/shadow.gsh
@@ -45,8 +45,8 @@ vec4 calculateTextureHash() {
 }
 
 void main() {
-    // Skip voxelization after the first tracer frame (F1 press handled in prepare_frame)
-    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame > 1) {
+    // Voxelize geometry every frame to handle newly loaded chunks
+    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- clear voxel data every frame so new chunks load
- remove frame-dependent guard logic in voxelization

## Testing
- `glslc shaders/program/prepare_frame.csh -o /tmp/prepare_frame.spv` *(fails: cannot find include file)*

------
https://chatgpt.com/codex/tasks/task_e_688980a706448330b1322c762eb5ea04