### PR TITLE
Fix aspect ratio sampling in lens

### DIFF
--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,6 +10,7 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
+uniform float viewWidth;
 uniform float viewHeight;
 
 /* RENDERTARGETS: 0 */
@@ -17,6 +18,7 @@ layout(location = 0) out vec3 color;
 
 void main() {
     vec2 filmCoord = texcoord * 2.0 - 1.0;
+    filmCoord.x *= viewWidth / viewHeight;
     color = getFilmAverageColor(filmCoord);
 #ifdef NEIGHBOURHOOD_CLAMPING
     vec3 maxNeighbour = max(

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -25,7 +25,9 @@ void pathTracer(vec2 fragCoord) {
 
     ivec3 voxelOffset = ivec3(renderState.viewMatrixInverse[2].xyz * VOXEL_OFFSET);
 
-    vec2 filmSample = (fragCoord + random2()) / vec2(viewWidth, viewHeight) * 2.0 - 1.0;
+    vec2 filmSample = (fragCoord + random2()) / vec2(viewWidth, viewHeight);
+    filmSample = filmSample * 2.0 - 1.0;
+    filmSample.x *= viewWidth / viewHeight;
 
 #ifdef SKY_CONTRIBUTION
     vec3 sunPosition = renderState.sunPosition;
@@ -152,7 +154,9 @@ void pathTracer(vec2 fragCoord) {
 }
 
 void preview(vec2 fragCoord) {
-    vec2 filmCoord = (fragCoord + 0.5) / vec2(viewWidth, viewHeight) * 2.0 - 1.0;
+    vec2 filmCoord = (fragCoord + 0.5) / vec2(viewWidth, viewHeight);
+    filmCoord = filmCoord * 2.0 - 1.0;
+    filmCoord.x *= viewWidth / viewHeight;
     ivec3 voxelOffset = ivec3(renderState.viewMatrixInverse[2].xyz * VOXEL_OFFSET);
 
     ray r = generatePinholeCameraRay(filmCoord);


### PR DESCRIPTION
## Summary
- scale film sampling by view aspect ratio
- include viewWidth uniform in composite shader

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools`

------
https://chatgpt.com/codex/tasks/task_e_688a41dae38483309a81f3e6e6ea1e4c