### PR TITLE
Fix camera aspect ratio calculation

### DIFF
--- a/shaders/lib/lens/common.glsl
+++ b/shaders/lib/lens/common.glsl
@@ -18,8 +18,15 @@ struct lens_element {
 };
 
 vec2 getSensorPhysicalExtent(sensor_data data) {
-    float aspect = renderState.projection[1][1] / renderState.projection[0][0];
-    float verticalFov = 2.0 * atan(1.0 / renderState.projection[1][1]);
+    /*
+     * In some setups the projection matrix entries can have a negative sign or
+     * be transposed depending on the driver. This resulted in the calculated
+     * aspect ratio and field of view being incorrect which caused the rendered
+     * image to appear in an oval shaped region. Using the absolute value ensures
+     * a positive ratio regardless of matrix orientation.
+     */
+    float aspect = abs(renderState.projection[1][1] / renderState.projection[0][0]);
+    float verticalFov = 2.0 * atan(1.0 / abs(renderState.projection[1][1]));
     float sensorHeight = 2.0 * renderState.focalLength * tan(verticalFov * 0.5);
     float sensorWidth = sensorHeight / aspect;
 


### PR DESCRIPTION
## Summary
- fix aspect ratio math in `getSensorPhysicalExtent`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a41dae38483309a81f3e6e6ea1e4c