### PR TITLE
Fix sensor aspect used for exit pupil

### DIFF
--- a/shaders/lib/lens/sampling.glsl
+++ b/shaders/lib/lens/sampling.glsl
@@ -25,8 +25,9 @@ vec2 samplePointOnRearElement(vec2 rand, out float weight) {
 }
 
 vec2 sampleExitPupil(vec2 rand, vec2 pointOnSensor, vec2 sensorExtent, out float weight) {
-    float sampleRadius = length(pointOnSensor);
-    float physicalRadius = length(sensorExtent);
+    // Use the maximum axis to avoid oval shaped vignetting on non square sensors
+    float sampleRadius = max(abs(pointOnSensor.x), abs(pointOnSensor.y));
+    float physicalRadius = max(sensorExtent.x, sensorExtent.y);
     float index = 255.0 * sampleRadius / physicalRadius;
     pupil_bounds bounds1 = renderState.exitPupil.samples[clamp(int(ceil(index)), 0, 255)];
     pupil_bounds bounds2 = renderState.exitPupil.samples[clamp(int(floor(index)), 0, 255)];

--- a/shaders/program/camera/prepare/exit_pupil.csh
+++ b/shaders/program/camera/prepare/exit_pupil.csh
@@ -7,7 +7,8 @@ const ivec3 workGroups = ivec3(8, 1, 1);
 
 void main() {
     vec2 sensorExtent = getSensorPhysicalExtent(CAMERA_SENSOR);
-    float physicalRadius = length(sensorExtent);
+    // Use the largest sensor dimension to ensure we cover the whole sensor
+    float physicalRadius = max(sensorExtent.x, sensorExtent.y);
 
     float sampleRadius = physicalRadius * float(gl_GlobalInvocationID.x) / 255.0;
     vec3 filmPoint = vec3(sampleRadius, 0.0, 0.0);


### PR DESCRIPTION
## Summary
- correct exit pupil radius calculation for rectangular sensors
- avoid oval-shaped vignetting when sampling the exit pupil

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a41dae38483309a81f3e6e6ea1e4c