### PR TITLE
Fix aspect ratio when GUI is visible

### DIFF
--- a/shaders/program/camera/exposure/histogram.csh
+++ b/shaders/program/camera/exposure/histogram.csh
@@ -9,8 +9,6 @@
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
-uniform float viewWidth;
-uniform float viewHeight;
 
 shared uint histogramShared[256];
 
@@ -32,7 +30,7 @@ void main() {
         return;
     }
 
-    uvec2 dim = uvec2(viewWidth, viewHeight);
+    uvec2 dim = uvec2(imageSize(filmBuffer));
     if (gl_GlobalInvocationID.x < dim.x && gl_GlobalInvocationID.y < dim.y) {
         vec3 color = getFilmAverageColor(ivec2(gl_GlobalInvocationID.xy));
         uint binIndex = colorToBin(color);

--- a/shaders/program/camera/exposure/luminance.csh
+++ b/shaders/program/camera/exposure/luminance.csh
@@ -9,8 +9,6 @@
 layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
-uniform float viewWidth;
-uniform float viewHeight;
 
 shared uint histogramShared[256];
 
@@ -39,7 +37,8 @@ void main() {
     }
 
     if (gl_LocalInvocationIndex == 0u) {
-        float logAverage = (float(histogramShared[0]) / max(viewWidth * viewHeight - float(count), 1.0)) - 1.0;
+        ivec2 dim = imageSize(filmBuffer);
+        float logAverage = (float(histogramShared[0]) / max(float(dim.x * dim.y) - float(count), 1.0)) - 1.0;
         float avgLum = fromLogLuminance(logAverage / 254.0);
 
         renderState.avgLuminance = avgLum;

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,15 +10,16 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
-uniform float viewWidth;
-uniform float viewHeight;
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec3 color;
 
 void main() {
+    ivec2 filmDim = textureSize(filmSampler, 0);
+    float width = float(filmDim.x);
+    float height = float(filmDim.y);
     vec2 filmCoord = texcoord * 2.0 - 1.0;
-    filmCoord.x *= viewWidth / viewHeight;
+    filmCoord.x *= width / height;
     color = getFilmAverageColor(filmCoord);
 #ifdef NEIGHBOURHOOD_CLAMPING
     vec3 maxNeighbour = max(
@@ -42,5 +43,5 @@ void main() {
     color = linearToSrgb(color);
 
     ivec2 time = ivec2(currentDate.x, currentYearTime.x);
-    renderTextOverlay(color, ivec2(gl_FragCoord.xy) / 2, ivec2(1.0, viewHeight * 0.5 - 1.0), time, frameTimeSmooth);
+    renderTextOverlay(color, ivec2(gl_FragCoord.xy) / 2, ivec2(1.0, height * 0.5 - 1.0), time, frameTimeSmooth);
 }


### PR DESCRIPTION
## Summary
- compute frame dimensions from `filmBuffer` instead of `viewWidth`/`viewHeight`
- apply this change to the main renderer, composite pass and exposure calculations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a4585a9a883308547e8995d9bd1d7