### PR TITLE
Fix camera stretching without F1

### DIFF
--- a/shaders/program/camera/lens_focus.csh
+++ b/shaders/program/camera/lens_focus.csh
@@ -6,7 +6,12 @@ layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
 void main() {
-    if (renderState.frame != 1) {
+    // Run focusing on the first frame even if the GUI is visible so the
+    // camera parameters are initialized correctly. Previously this pass only
+    // executed when `renderState.frame` was exactly 1 which required the user
+    // to hide the GUI (F1) once. Allow frames 0 and 1 to perform focusing by
+    // skipping only when the frame counter has advanced beyond initialization.
+    if (renderState.frame > 1) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- execute lens focusing pass even when the GUI is shown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a48a6da2483309a1a924c1ac404e0