### PR TITLE
Fix aspect ratio when GUI is visible

### DIFF
--- a/shaders/program/camera/exposure/histogram.csh
+++ b/shaders/program/camera/exposure/histogram.csh
@@ -9,6 +9,8 @@
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
+uniform float viewWidth;
+uniform float viewHeight;
 
 shared uint histogramShared[256];
 
@@ -30,7 +32,7 @@ void main() {
         return;
     }
 
-    uvec2 dim = uvec2(imageSize(filmBuffer));
+    uvec2 dim = uvec2(viewWidth, viewHeight);
     if (gl_GlobalInvocationID.x < dim.x && gl_GlobalInvocationID.y < dim.y) {
         vec3 color = getFilmAverageColor(ivec2(gl_GlobalInvocationID.xy));
         uint binIndex = colorToBin(color);

--- a/shaders/program/camera/exposure/luminance.csh
+++ b/shaders/program/camera/exposure/luminance.csh
@@ -9,6 +9,8 @@
 layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
+uniform float viewWidth;
+uniform float viewHeight;
 
 shared uint histogramShared[256];
 
@@ -37,8 +39,7 @@ void main() {
     }
 
     if (gl_LocalInvocationIndex == 0u) {
-        ivec2 dim = imageSize(filmBuffer);
-        float logAverage = (float(histogramShared[0]) / max(float(dim.x * dim.y) - float(count), 1.0)) - 1.0;
+        float logAverage = (float(histogramShared[0]) / max(viewWidth * viewHeight - float(count), 1.0)) - 1.0;
         float avgLum = fromLogLuminance(logAverage / 254.0);
 
         renderState.avgLuminance = avgLum;

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,14 +10,15 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
+uniform float viewWidth;
+uniform float viewHeight;
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec3 color;
 
 void main() {
-    ivec2 filmDim = textureSize(filmSampler, 0);
-    float width = float(filmDim.x);
-    float height = float(filmDim.y);
+    float width = viewWidth;
+    float height = viewHeight;
     vec2 filmCoord = texcoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
     color = getFilmAverageColor(filmCoord);

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -17,10 +17,12 @@ layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
 
+uniform float viewWidth;
+uniform float viewHeight;
+
 void pathTracer(vec2 fragCoord) {
-    ivec2 filmDim = imageSize(filmBuffer);
-    float width = float(filmDim.x);
-    float height = float(filmDim.y);
+    float width = viewWidth;
+    float height = viewHeight;
     float lambdaPDF;
     int lambda = sampleWavelength(random1(), lambdaPDF);
 
@@ -155,9 +157,8 @@ void pathTracer(vec2 fragCoord) {
 }
 
 void preview(vec2 fragCoord) {
-    ivec2 filmDim = imageSize(filmBuffer);
-    float width = float(filmDim.x);
-    float height = float(filmDim.y);
+    float width = viewWidth;
+    float height = viewHeight;
     vec2 filmCoord = (fragCoord + 0.5) / vec2(width, height);
     filmCoord = filmCoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
@@ -188,9 +189,8 @@ void main() {
     currentIOR = 1.0;
     currentMediumAbsorbtance = 0.0;
 
-    ivec2 filmDim = imageSize(filmBuffer);
-    float width = float(filmDim.x);
-    float height = float(filmDim.y);
+    float width = viewWidth;
+    float height = viewHeight;
 
     vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
     if (fragCoord.x > width || fragCoord.y > height) return;


### PR DESCRIPTION
## Summary
- ensure shaders use view width/height rather than film buffer size
- restore uniforms in exposure, render and composite passes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a48a6da2483309a1a924c1ac404e0