### PR TITLE
Fix resolution mismatch in preview mode

### DIFF
--- a/shaders/program/camera/exposure/histogram.csh
+++ b/shaders/program/camera/exposure/histogram.csh
@@ -9,8 +9,8 @@
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
-uniform float viewWidth;
-uniform float viewHeight;
+// Derive the target dimensions from the film buffer because the uniforms can
+// be invalid during preview.
 
 shared uint histogramShared[256];
 
@@ -32,7 +32,7 @@ void main() {
         return;
     }
 
-    uvec2 dim = uvec2(viewWidth, viewHeight);
+    uvec2 dim = uvec2(imageSize(filmBuffer));
     if (gl_GlobalInvocationID.x < dim.x && gl_GlobalInvocationID.y < dim.y) {
         vec3 color = getFilmAverageColor(ivec2(gl_GlobalInvocationID.xy));
         uint binIndex = colorToBin(color);

--- a/shaders/program/camera/exposure/luminance.csh
+++ b/shaders/program/camera/exposure/luminance.csh
@@ -9,8 +9,8 @@
 layout (local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
-uniform float viewWidth;
-uniform float viewHeight;
+// The preview stage may not populate viewport uniforms. Use the film buffer
+// dimensions instead when computing statistics.
 
 shared uint histogramShared[256];
 
@@ -39,7 +39,8 @@ void main() {
     }
 
     if (gl_LocalInvocationIndex == 0u) {
-        float logAverage = (float(histogramShared[0]) / max(viewWidth * viewHeight - float(count), 1.0)) - 1.0;
+        ivec2 dim = imageSize(filmBuffer);
+        float logAverage = (float(histogramShared[0]) / max(float(dim.x * dim.y) - float(count), 1.0)) - 1.0;
         float avgLum = fromLogLuminance(logAverage / 254.0);
 
         renderState.avgLuminance = avgLum;

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,15 +10,16 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
-uniform float viewWidth;
-uniform float viewHeight;
+// The preview mode doesn't always provide valid viewport uniforms.
+// Query the film texture size instead.
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec3 color;
 
 void main() {
-    float width = viewWidth;
-    float height = viewHeight;
+    ivec2 dim = textureSize(filmSampler, 0);
+    float width = float(dim.x);
+    float height = float(dim.y);
     vec2 filmCoord = texcoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
     color = getFilmAverageColor(filmCoord);

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -17,12 +17,13 @@ layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
 
-uniform float viewWidth;
-uniform float viewHeight;
+// Viewport uniforms may not be valid before rendering starts, so derive the
+// dimensions from the film buffer instead.
 
 void pathTracer(vec2 fragCoord) {
-    float width = viewWidth;
-    float height = viewHeight;
+    ivec2 dim = imageSize(filmBuffer);
+    float width = float(dim.x);
+    float height = float(dim.y);
     float lambdaPDF;
     int lambda = sampleWavelength(random1(), lambdaPDF);
 
@@ -157,8 +158,9 @@ void pathTracer(vec2 fragCoord) {
 }
 
 void preview(vec2 fragCoord) {
-    float width = viewWidth;
-    float height = viewHeight;
+    ivec2 dim = imageSize(filmBuffer);
+    float width = float(dim.x);
+    float height = float(dim.y);
     vec2 filmCoord = (fragCoord + 0.5) / vec2(width, height);
     filmCoord = filmCoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
@@ -189,8 +191,9 @@ void main() {
     currentIOR = 1.0;
     currentMediumAbsorbtance = 0.0;
 
-    float width = viewWidth;
-    float height = viewHeight;
+    ivec2 dim = imageSize(filmBuffer);
+    float width = float(dim.x);
+    float height = float(dim.y);
 
     vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
     if (fragCoord.x > width || fragCoord.y > height) return;


### PR DESCRIPTION
## Summary
- query film texture size instead of relying on viewWidth/viewHeight uniforms
- fix render and exposure compute shaders to use filmBuffer dimensions

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688a4ce088e883308a7995744588c36d