### PR TITLE
Fix viewport dimension handling

### DIFF
--- a/shaders/program/camera/exposure/histogram.csh
+++ b/shaders/program/camera/exposure/histogram.csh
@@ -9,8 +9,11 @@
 layout (local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
-// Derive the target dimensions from the film buffer because the uniforms can
-// be invalid during preview.
+uniform float viewWidth;
+uniform float viewHeight;
+
+// Derive the target dimensions from the film buffer if the viewport uniforms are
+// invalid during preview.
 
 shared uint histogramShared[256];
 
@@ -32,7 +35,10 @@ void main() {
         return;
     }
 
-    uvec2 dim = uvec2(imageSize(filmBuffer));
+    uvec2 dim = uvec2(viewWidth, viewHeight);
+    if (dim.x == 0u || dim.y == 0u) {
+        dim = uvec2(imageSize(filmBuffer));
+    }
     if (gl_GlobalInvocationID.x < dim.x && gl_GlobalInvocationID.y < dim.y) {
         vec3 color = getFilmAverageColor(ivec2(gl_GlobalInvocationID.xy));
         uint binIndex = colorToBin(color);

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,16 +10,22 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
-// The preview mode doesn't always provide valid viewport uniforms.
-// Query the film texture size instead.
+// Use the actual viewport dimensions whenever possible.
+// Fall back to the film texture size if the values are invalid.
+uniform float viewWidth;
+uniform float viewHeight;
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec3 color;
 
 void main() {
     ivec2 dim = textureSize(filmSampler, 0);
-    float width = float(dim.x);
-    float height = float(dim.y);
+    float width = viewWidth;
+    float height = viewHeight;
+    if (width <= 0.0 || height <= 0.0) {
+        width = float(dim.x);
+        height = float(dim.y);
+    }
     vec2 filmCoord = texcoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
     color = getFilmAverageColor(filmCoord);

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -16,14 +16,20 @@
 layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
+uniform float viewWidth;
+uniform float viewHeight;
 
-// Viewport uniforms may not be valid before rendering starts, so derive the
-// dimensions from the film buffer instead.
+// Viewport uniforms may not be valid before rendering starts. If they're
+// invalid, fall back to the film buffer dimensions.
 
 void pathTracer(vec2 fragCoord) {
     ivec2 dim = imageSize(filmBuffer);
-    float width = float(dim.x);
-    float height = float(dim.y);
+    float width = viewWidth;
+    float height = viewHeight;
+    if (width <= 0.0 || height <= 0.0) {
+        width = float(dim.x);
+        height = float(dim.y);
+    }
     float lambdaPDF;
     int lambda = sampleWavelength(random1(), lambdaPDF);
 
@@ -159,8 +165,12 @@ void pathTracer(vec2 fragCoord) {
 
 void preview(vec2 fragCoord) {
     ivec2 dim = imageSize(filmBuffer);
-    float width = float(dim.x);
-    float height = float(dim.y);
+    float width = viewWidth;
+    float height = viewHeight;
+    if (width <= 0.0 || height <= 0.0) {
+        width = float(dim.x);
+        height = float(dim.y);
+    }
     vec2 filmCoord = (fragCoord + 0.5) / vec2(width, height);
     filmCoord = filmCoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
@@ -192,8 +202,12 @@ void main() {
     currentMediumAbsorbtance = 0.0;
 
     ivec2 dim = imageSize(filmBuffer);
-    float width = float(dim.x);
-    float height = float(dim.y);
+    float width = viewWidth;
+    float height = viewHeight;
+    if (width <= 0.0 || height <= 0.0) {
+        width = float(dim.x);
+        height = float(dim.y);
+    }
 
     vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
     if (fragCoord.x > width || fragCoord.y > height) return;


### PR DESCRIPTION
## Summary
- detect invalid viewport uniforms and fallback to film texture size
- use viewport size when compositing and rendering to avoid stretched output
- update exposure compute shaders accordingly

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688a4f99a9608330ba16a6bd7a163679