### PR TITLE
Revert viewport uniform logic

### DIFF
--- a/shaders/lib/lens/common.glsl
+++ b/shaders/lib/lens/common.glsl
@@ -18,15 +18,8 @@ struct lens_element {
 };
 
 vec2 getSensorPhysicalExtent(sensor_data data) {
-    /*
-     * In some setups the projection matrix entries can have a negative sign or
-     * be transposed depending on the driver. This resulted in the calculated
-     * aspect ratio and field of view being incorrect which caused the rendered
-     * image to appear in an oval shaped region. Using the absolute value ensures
-     * a positive ratio regardless of matrix orientation.
-     */
-    float aspect = abs(renderState.projection[1][1] / renderState.projection[0][0]);
-    float verticalFov = 2.0 * atan(1.0 / abs(renderState.projection[1][1]));
+    float aspect = renderState.projection[1][1] / renderState.projection[0][0];
+    float verticalFov = 2.0 * atan(1.0 / renderState.projection[1][1]);
     float sensorHeight = 2.0 * renderState.focalLength * tan(verticalFov * 0.5);
     float sensorWidth = sensorHeight / aspect;
 

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -10,22 +10,16 @@
 in vec2 texcoord;
 
 uniform float frameTimeSmooth;
-// Use the actual viewport dimensions whenever possible.
-// Fall back to the film texture size if the values are invalid.
-uniform float viewWidth;
-uniform float viewHeight;
+// The preview mode doesn't always provide valid viewport uniforms.
+// Query the film texture size instead.
 
 /* RENDERTARGETS: 0 */
 layout(location = 0) out vec3 color;
 
 void main() {
     ivec2 dim = textureSize(filmSampler, 0);
-    float width = viewWidth;
-    float height = viewHeight;
-    if (width <= 0.0 || height <= 0.0) {
-        width = float(dim.x);
-        height = float(dim.y);
-    }
+    float width = float(dim.x);
+    float height = float(dim.y);
     vec2 filmCoord = texcoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
     color = getFilmAverageColor(filmCoord);

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -16,20 +16,13 @@
 layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
-uniform float viewWidth;
-uniform float viewHeight;
-
-// Viewport uniforms may not be valid before rendering starts. If they're
-// invalid, fall back to the film buffer dimensions.
+// Viewport uniforms may not be valid before rendering starts, so derive the
+// dimensions from the film buffer instead.
 
 void pathTracer(vec2 fragCoord) {
     ivec2 dim = imageSize(filmBuffer);
-    float width = viewWidth;
-    float height = viewHeight;
-    if (width <= 0.0 || height <= 0.0) {
-        width = float(dim.x);
-        height = float(dim.y);
-    }
+    float width = float(dim.x);
+    float height = float(dim.y);
     float lambdaPDF;
     int lambda = sampleWavelength(random1(), lambdaPDF);
 
@@ -165,12 +158,8 @@ void pathTracer(vec2 fragCoord) {
 
 void preview(vec2 fragCoord) {
     ivec2 dim = imageSize(filmBuffer);
-    float width = viewWidth;
-    float height = viewHeight;
-    if (width <= 0.0 || height <= 0.0) {
-        width = float(dim.x);
-        height = float(dim.y);
-    }
+    float width = float(dim.x);
+    float height = float(dim.y);
     vec2 filmCoord = (fragCoord + 0.5) / vec2(width, height);
     filmCoord = filmCoord * 2.0 - 1.0;
     filmCoord.x *= width / height;
@@ -202,12 +191,8 @@ void main() {
     currentMediumAbsorbtance = 0.0;
 
     ivec2 dim = imageSize(filmBuffer);
-    float width = viewWidth;
-    float height = viewHeight;
-    if (width <= 0.0 || height <= 0.0) {
-        width = float(dim.x);
-        height = float(dim.y);
-    }
+    float width = float(dim.x);
+    float height = float(dim.y);
 
     vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
     if (fragCoord.x > width || fragCoord.y > height) return;


### PR DESCRIPTION
## Summary
- revert composite shader to rely on film texture size rather than viewport dimensions
- revert compute path tracer to query film buffer size instead of viewport uniforms
- simplify camera aspect calculation logic in `common.glsl`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688adff601e8833089eddacfbfcfd1f4