### PR TITLE
Fix aspect ratio handling and out-of-range threads

### DIFF
--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -195,7 +195,7 @@ void main() {
     float height = float(dim.y);
 
     vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
-    if (fragCoord.x > width || fragCoord.y > height) return;
+    if (fragCoord.x >= width || fragCoord.y >= height) return;
 
     initGlobalPRNG(fragCoord / vec2(width, height), renderState.frame);
 


### PR DESCRIPTION
## Summary
- avoid sampling outside the film buffer when screen aspect ratio differs
- clamp compute shader dispatch bounds

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools`
- `glslangValidator -S comp shaders/program/main/render.csh` *(fails: '#include' : required extension not requested)*


------
https://chatgpt.com/codex/tasks/task_e_688aea2a06708330a5437762123b945c