### PR TITLE
Fix render artifacts by clearing full film buffer

### DIFF
--- a/shaders/program/camera/prepare/clear_frame.csh
+++ b/shaders/program/camera/prepare/clear_frame.csh
@@ -5,8 +5,14 @@ layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
 void main() {
-    if (renderState.clear) {
-        imageStore(filmBuffer, ivec2(gl_GlobalInvocationID.xy), vec4(0.0));
-        imageStore(splatBuffer, ivec2(gl_GlobalInvocationID.xy), vec4(0.0));
+    ivec2 dim = imageSize(filmBuffer);
+
+    for (int y = int(gl_GlobalInvocationID.y); y < dim.y; y += int(gl_NumWorkGroups.y) * int(gl_WorkGroupSize.y)) {
+        for (int x = int(gl_GlobalInvocationID.x); x < dim.x; x += int(gl_NumWorkGroups.x) * int(gl_WorkGroupSize.x)) {
+            if (renderState.clear) {
+                imageStore(filmBuffer, ivec2(x, y), vec4(0.0));
+                imageStore(splatBuffer, ivec2(x, y), vec4(0.0));
+            }
+        }
     }
 }

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -194,14 +194,16 @@ void main() {
     float width = float(dim.x);
     float height = float(dim.y);
 
-    vec2 fragCoord = vec2(gl_GlobalInvocationID.xy);
-    if (fragCoord.x >= width || fragCoord.y >= height) return;
+    for (int y = int(gl_GlobalInvocationID.y); y < dim.y; y += int(gl_NumWorkGroups.y) * int(gl_WorkGroupSize.y)) {
+        for (int x = int(gl_GlobalInvocationID.x); x < dim.x; x += int(gl_NumWorkGroups.x) * int(gl_WorkGroupSize.x)) {
+            vec2 fragCoord = vec2(x, y);
+            initGlobalPRNG(fragCoord / vec2(width, height), renderState.frame);
 
-    initGlobalPRNG(fragCoord / vec2(width, height), renderState.frame);
-
-    if (renderState.frame == 0) {
-        preview(fragCoord);
-    } else {
-        pathTracer(fragCoord);
+            if (renderState.frame == 0) {
+                preview(fragCoord);
+            } else {
+                pathTracer(fragCoord);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ensure clear_frame covers entire film buffer even when dispatch sizes are limited
- iterate over full render target in main compute shader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688aec915ec08330a5f3f5e0c3974458