### PR TITLE
Fix heavy compute when GUI visible

### DIFF
--- a/shaders/program/camera/lens_focus.csh
+++ b/shaders/program/camera/lens_focus.csh
@@ -2,11 +2,13 @@
 #include "/lib/lens/focusing.glsl"
 #include "/lib/raytracing/trace.glsl"
 
+uniform bool hideGUI;
+
 layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
 void main() {
-    if (renderState.frame > 1) {
+    if (!hideGUI || renderState.frame > 1) {
         return;
     }
 

--- a/shaders/program/camera/prepare/exit_pupil.csh
+++ b/shaders/program/camera/prepare/exit_pupil.csh
@@ -2,10 +2,15 @@
 #include "/lib/buffer/state.glsl"
 #include "/lib/lens/tracing.glsl"
 
+uniform bool hideGUI;
+
 layout (local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(8, 1, 1);
 
 void main() {
+    if (!hideGUI) {
+        return;
+    }
     vec2 sensorExtent = getSensorPhysicalExtent(CAMERA_SENSOR);
     // Use the largest sensor dimension to ensure we cover the whole sensor
     float physicalRadius = max(sensorExtent.x, sensorExtent.y);


### PR DESCRIPTION
## Summary
- avoid heavy camera focus work while the GUI is on
- skip expensive exit pupil generation until rendering starts

## Testing
- `glslangValidator -S comp shaders/program/camera/lens_focus.csh`


------
https://chatgpt.com/codex/tasks/task_e_688aef0fcf3c8330b822357638eb1163