### PR TITLE
Allow path tracing without hiding GUI

### DIFF
--- a/shaders/program/camera/lens_focus.csh
+++ b/shaders/program/camera/lens_focus.csh
@@ -8,7 +8,7 @@ layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
 void main() {
-    if (!hideGUI || renderState.frame > 1) {
+    if (renderState.frame > 1) {
         return;
     }
 

--- a/shaders/program/camera/prepare/exit_pupil.csh
+++ b/shaders/program/camera/prepare/exit_pupil.csh
@@ -8,9 +8,6 @@ layout (local_size_x = 32, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(8, 1, 1);
 
 void main() {
-    if (!hideGUI) {
-        return;
-    }
     vec2 sensorExtent = getSensorPhysicalExtent(CAMERA_SENSOR);
     // Use the largest sensor dimension to ensure we cover the whole sensor
     float physicalRadius = max(sensorExtent.x, sensorExtent.y);

--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -5,6 +5,7 @@
 layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(1, 1, 1);
 
+// Kept for compatibility but no longer used to gate rendering
 uniform bool hideGUI;
 
 uniform vec3 sunPosition;
@@ -19,16 +20,16 @@ uniform float eyeAltitude;
 uniform int worldTime;
 
 void main() {
-    if (hideGUI) {
-        renderState.frame++;
-    } else {
-        renderState.frame = 0;
+    // Continue accumulating even when the GUI is visible
+    renderState.frame++;
+
+    if (renderState.frame == 1) {
         renderState.invalidSplat = 0;
         renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
         renderState.localTime = currentLocalTime();
 #ifndef USE_SYSTEM_TIME
         datetime time2 = renderState.localTime;
-        
+
         time2.hour = 6;
         time2.minute = 0;
         time2.second = 0;

--- a/shaders/program/voxelization/prepare/clear_structures.csh
+++ b/shaders/program/voxelization/prepare/clear_structures.csh
@@ -8,9 +8,6 @@ layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 const ivec3 workGroups = ivec3(65535, 1, 1);
 uniform bool hideGUI;
 void main() {
-    if (!hideGUI) {
-        return;
-    }
     // Clear voxel structures every frame so newly loaded chunks do not keep stale data
     if (renderState.frame != 1) {
         return;


### PR DESCRIPTION
## Summary
- let the frame counter increment regardless of F1 state
- drop `hideGUI` checks so camera focus and voxel data update even with the GUI visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688af249fc508330ac03e1e7beaf6913