### PR TITLE
Optimize preview voxelization

### DIFF
--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -51,11 +51,13 @@ void main() {
     renderState.clear = (renderState.frame <= 1);
 
     if (renderState.frame <= 1) {
-        quadBuffer.aabb = scene_aabb(10000, 10000, 10000, -10000, -10000, -10000);
-        quadBuffer.count = 0u;
+        if (hideGUI) {
+            quadBuffer.aabb = scene_aabb(10000, 10000, 10000, -10000, -10000, -10000);
+            quadBuffer.count = 0u;
 
-        renderState.entityData.textureIndex = 0u;
-        renderState.entityData.cellIndex = 0u;
+            renderState.entityData.textureIndex = 0u;
+            renderState.entityData.cellIndex = 0u;
+        }
 
         renderState.projection = gbufferProjection;
         renderState.projectionInverse = gbufferProjectionInverse;

--- a/shaders/program/voxelization/shadow.gsh
+++ b/shaders/program/voxelization/shadow.gsh
@@ -46,9 +46,10 @@ vec4 calculateTextureHash() {
 
 void main() {
     // Voxelize geometry during preview so the initial frame is visible.
-    // This may run each frame while renderState.frame is 0 or 1, but
-    // ensures geometry is present before rendering actually begins.
-    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame > 1) {
+    // Avoid repeating the costly operation every preview frame by
+    // skipping once geometry has been cached.
+    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 ||
+        (renderState.frame == 0 && quadBuffer.count > 0u) || renderState.frame > 1) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid clearing voxel data every preview frame
- skip expensive voxelization once geometry is cached

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688af93cfd7483308972ea3bcf91261e