### PR TITLE
Fix performance before rendering

### DIFF
--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -13,6 +13,8 @@
 #include "/lib/utility/sampling.glsl"
 #include "/lib/settings.glsl"
 
+uniform bool hideGUI;
+
 layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
@@ -190,6 +192,10 @@ void main() {
     currentIOR = 1.0;
     currentMediumAbsorbtance = 0.0;
 
+    if (!hideGUI && renderState.frame > 0) {
+        return;
+    }
+
     ivec2 dim = imageSize(filmBuffer);
     float width = float(dim.x);
     float height = float(dim.y);
@@ -205,5 +211,9 @@ void main() {
                 pathTracer(fragCoord);
             }
         }
+    }
+
+    if (renderState.frame == 0) {
+        renderState.frame = 1;
     }
 }

--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -22,10 +22,13 @@ void main() {
     if (hideGUI) {
         renderState.frame++;
     } else {
-        renderState.frame = 0;
-        renderState.invalidSplat = 0;
-        renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
-        renderState.localTime = currentLocalTime();
+        if (renderState.frame > 1) {
+            renderState.frame = 0;
+        }
+        if (renderState.frame == 0) {
+            renderState.invalidSplat = 0;
+            renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
+            renderState.localTime = currentLocalTime();
 #ifndef USE_SYSTEM_TIME
         datetime time2 = renderState.localTime;
         
@@ -46,6 +49,7 @@ void main() {
         renderState.sunPosition = getMinecraftSunPosition(mat3(gbufferModelViewInverse) * sunPosition);
 #endif
         renderState.sunDirection = normalize(renderState.sunPosition);
+        }
     }
 
     renderState.clear = (renderState.frame <= 1);

--- a/shaders/program/voxelization/shadow.gsh
+++ b/shaders/program/voxelization/shadow.gsh
@@ -45,10 +45,9 @@ vec4 calculateTextureHash() {
 }
 
 void main() {
-    // Voxelize geometry during preview so the initial frame is visible.
-    // This may run each frame while renderState.frame is 0 or 1, but
-    // ensures geometry is present before rendering actually begins.
-    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame > 1) {
+    // Voxelize geometry only on the very first frame so the initial preview
+    // has valid geometry without repeatedly reprocessing every tick.
+    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame > 0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid repeatedly resetting render frame in `prepare_frame.csh`
- skip compute work when GUI is visible
- only voxelize geometry on the very first preview frame

## Testing
- `git diff --check`
- *(failed to run `glslangValidator` due to missing command)*

------
https://chatgpt.com/codex/tasks/task_e_688af93cfd7483308972ea3bcf91261e