### PR TITLE
Fix preview lag by processing geometry only once

### DIFF
--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -16,6 +16,8 @@
 layout (local_size_x = 8, local_size_y = 4, local_size_z = 1) in;
 const vec2 workGroupsRender = vec2(1.0, 1.0);
 
+uniform bool hideGUI;
+
 // Viewport uniforms may not be valid before rendering starts, so derive the
 // dimensions from the film buffer instead.
 
@@ -199,11 +201,14 @@ void main() {
             vec2 fragCoord = vec2(x, y);
             initGlobalPRNG(fragCoord / vec2(width, height), renderState.frame);
 
-            if (renderState.frame == 0) {
-                preview(fragCoord);
-            } else {
+            if (hideGUI) {
                 pathTracer(fragCoord);
+            } else if (renderState.frame == 0) {
+                preview(fragCoord);
             }
         }
+    }
+    if (!hideGUI && renderState.frame == 0) {
+        renderState.frame = 1;
     }
 }

--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -22,35 +22,37 @@ void main() {
     if (hideGUI) {
         renderState.frame++;
     } else {
-        renderState.frame = 0;
-        renderState.invalidSplat = 0;
-        renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
-        renderState.localTime = currentLocalTime();
+        if (renderState.frame != 1) {
+            renderState.frame = 0;
+            renderState.invalidSplat = 0;
+            renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
+            renderState.localTime = currentLocalTime();
 #ifndef USE_SYSTEM_TIME
-        datetime time2 = renderState.localTime;
-        
-        time2.hour = 6;
-        time2.minute = 0;
-        time2.second = 0;
+            datetime time2 = renderState.localTime;
 
-        time2 = unixToDatetime(datetimeToUnix(time2) + uint(float(worldTime) * 3.6));
+            time2.hour = 6;
+            time2.minute = 0;
+            time2.second = 0;
 
-        renderState.localTime.hour = time2.hour;
-        renderState.localTime.minute = time2.minute;
-        renderState.localTime.second = time2.second;
+            time2 = unixToDatetime(datetimeToUnix(time2) + uint(float(worldTime) * 3.6));
+
+            renderState.localTime.hour = time2.hour;
+            renderState.localTime.minute = time2.minute;
+            renderState.localTime.second = time2.second;
 #endif
 #if (SUN_PATH_TYPE == 1)
-        datetime utcTime = convertToUniversalTime(renderState.localTime);
-        renderState.sunPosition = getRealisticSunPosition(utcTime, getGeographicCoordinates());
+            datetime utcTime = convertToUniversalTime(renderState.localTime);
+            renderState.sunPosition = getRealisticSunPosition(utcTime, getGeographicCoordinates());
 #else
-        renderState.sunPosition = getMinecraftSunPosition(mat3(gbufferModelViewInverse) * sunPosition);
+            renderState.sunPosition = getMinecraftSunPosition(mat3(gbufferModelViewInverse) * sunPosition);
 #endif
-        renderState.sunDirection = normalize(renderState.sunPosition);
+            renderState.sunDirection = normalize(renderState.sunPosition);
+        }
     }
 
-    renderState.clear = (renderState.frame <= 1);
+    renderState.clear = hideGUI ? (renderState.frame <= 2) : (renderState.frame == 0);
 
-    if (renderState.frame <= 1) {
+    if (renderState.frame == 0) {
         quadBuffer.aabb = scene_aabb(10000, 10000, 10000, -10000, -10000, -10000);
         quadBuffer.count = 0u;
 

--- a/shaders/program/voxelization/shadow.gsh
+++ b/shaders/program/voxelization/shadow.gsh
@@ -46,9 +46,8 @@ vec4 calculateTextureHash() {
 
 void main() {
     // Voxelize geometry during preview so the initial frame is visible.
-    // This may run each frame while renderState.frame is 0 or 1, but
-    // ensures geometry is present before rendering actually begins.
-    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame > 1) {
+    // Run only on the very first preview frame to avoid repeated work.
+    if (gl_PrimitiveIDIn % 2 != 0 || vColor[0].a == 0.0 || renderState.frame != 0) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- avoid repeated voxelization in preview by checking `renderState.frame` and updating it after the first frame
- run the path tracer only when `hideGUI` is active
- keep film buffers intact until rendering starts

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_688afc5b5b8483309adb1150735af16d