### PR TITLE
Optimize preview voxelization

### DIFF
--- a/shaders/program/prepare_frame.csh
+++ b/shaders/program/prepare_frame.csh
@@ -20,9 +20,17 @@ uniform int worldTime;
 
 void main() {
     if (hideGUI) {
-        renderState.frame++;
+        if (renderState.frame >= 2) {
+            // Restart rendering when exiting preview
+            renderState.frame = 1;
+        } else {
+            renderState.frame++;
+        }
     } else {
-        renderState.frame = 0;
+        // Advance once during preview so geometry is processed only on the first frame
+        if (renderState.frame < 2) {
+            renderState.frame++;
+        }
         renderState.invalidSplat = 0;
         renderState.startTime = ivec2(currentDate.x, currentYearTime.x);
         renderState.localTime = currentLocalTime();


### PR DESCRIPTION
## Summary
- update `prepare_frame.csh` logic so voxelization only happens on the first preview frame

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688afc5b5b8483309adb1150735af16d