### PR TITLE
Fix small render aperture

### DIFF
--- a/shaders/lib/settings.glsl
+++ b/shaders/lib/settings.glsl
@@ -30,7 +30,7 @@ const ivec3 HALF_VOXEL_VOLUME_SIZE = VOXEL_VOLUME_SIZE / 2;
 #define ISO 100 // [50 100 200 400 800 1600 3200]
 #define SHUTTER_SPEED 125 // [1500 1000 500 250 125 60 30 15 8]
 #define EV 0 // [-5 -4.5 -4 -3.5 -3 -2.5 -2 -1.5 -1 -0.75 -0.5 -0.25 0 +0.25 +0.5 +0.75 +1 +1.5 +2 +2.5 +3 +3.5 +4 +4.5 +5]
-#define F_NUMBER 16 // [0 1 1.4 2 2.8 4 5.6 8 11 16 22 32]
+#define F_NUMBER 0 // [0 1 1.4 2 2.8 4 5.6 8 11 16 22 32]
 
 #define VOXEL_OFFSET 0.0
 


### PR DESCRIPTION
## Summary
- open the lens aperture to its default size by setting `F_NUMBER` to 0

## Testing
- `grep -n "F_NUMBER" -R | head`

------
https://chatgpt.com/codex/tasks/task_e_688b04f4d2f88330bb654f62d87f202e