### PR TITLE
Fix circular crop when rendering via F1

### DIFF
--- a/shaders/program/camera/prepare/exit_pupil.csh
+++ b/shaders/program/camera/prepare/exit_pupil.csh
@@ -12,8 +12,10 @@ void main() {
         return;
     }
     vec2 sensorExtent = getSensorPhysicalExtent(CAMERA_SENSOR);
-    // Use the largest sensor dimension to ensure we cover the whole sensor
-    float physicalRadius = max(sensorExtent.x, sensorExtent.y);
+    // Use half the diagonal of the sensor to fully cover rectangular sensors
+    // when computing the exit pupil. This avoids circular cropping on screens
+    // with non-square aspect ratios.
+    float physicalRadius = length(sensorExtent) * 0.5;
 
     float sampleRadius = physicalRadius * float(gl_GlobalInvocationID.x) / 255.0;
     vec3 filmPoint = vec3(sampleRadius, 0.0, 0.0);


### PR DESCRIPTION
## Summary
- correct exit pupil radius calculation to always cover the entire sensor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b04f4d2f88330bb654f62d87f202e