### PR TITLE
Fix full-screen render

### DIFF
--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -59,8 +59,7 @@ void pathTracer(vec2 fragCoord) {
 #endif
 
     float cameraWeight = 1.0;
-    bool lensFlare = false;
-    ray r = generateCameraRay(lambda, filmSample, cameraWeight, lensFlare);
+    ray r = generatePinholeCameraRay(filmSample);
     if (cameraWeight == 0.0) {
         logFilmSample(filmSample, vec3(0.0));
         return;
@@ -75,7 +74,7 @@ void pathTracer(vec2 fragCoord) {
     for (int i = 0;; i++) {
         if (!traceRay(it, voxelOffset, r)) {
 #ifdef SKY_CONTRIBUTION
-            if ((i == 0 && !lensFlare) || (i > 0 && bsdfSample.dirac)) {
+            if (i == 0 || (i > 0 && bsdfSample.dirac)) {
                 ray earthRay = convertToEarthSpace(r);
                 if (intersectSphere(earthRay, sunPosition, sunRadius).x >= 0.0) {
                     float transmittance = estimateTransmittance(earthRay, extinctionBeta);


### PR DESCRIPTION
## Summary
- use pinhole camera for the final render pass
- avoid lens flare condition

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools`
- `glslangValidator -S comp shaders/program/main/render.csh` *(fails: required extension not requested)*

------
https://chatgpt.com/codex/tasks/task_e_688b04f4d2f88330bb654f62d87f202e