### PR TITLE
Fix AGX tone mapping color space

### DIFF
--- a/shaders/lib/post/agx.glsl
+++ b/shaders/lib/post/agx.glsl
@@ -46,9 +46,10 @@ vec3 agxEotf(vec3 val) {
     // Undo input transform
     val = agx_mat_inv * val;
 
-    // sRGB IEC 61966-2-1 2.2 Exponent Reference EOTF Display
-    // (Should I replace this with the actual sRGB conversion function?)
-    val = linearToSrgb(val);
+    // Convert from encoded values back to linear light using the sRGB EOTF
+    // before returning the result. This avoids applying gamma twice in the
+    // final composite shader.
+    val = srgbToLinear(val);
 
     return val;
 }


### PR DESCRIPTION
## Summary
- correct the AGX EOTF implementation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1c30d17c833088b776151c0dbfbc