### PR TITLE
Fix overexposure when starting path tracer

### DIFF
--- a/shaders/lib/settings.glsl
+++ b/shaders/lib/settings.glsl
@@ -30,7 +30,7 @@ const ivec3 HALF_VOXEL_VOLUME_SIZE = VOXEL_VOLUME_SIZE / 2;
 #define ISO 100 // [50 100 200 400 800 1600 3200]
 #define SHUTTER_SPEED 125 // [1500 1000 500 250 125 60 30 15 8]
 #define EV 0 // [-5 -4.5 -4 -3.5 -3 -2.5 -2 -1.5 -1 -0.75 -0.5 -0.25 0 +0.25 +0.5 +0.75 +1 +1.5 +2 +2.5 +3 +3.5 +4 +4.5 +5]
-#define F_NUMBER 0 // [0 1 1.4 2 2.8 4 5.6 8 11 16 22 32]
+#define F_NUMBER 16 // [0 1 1.4 2 2.8 4 5.6 8 11 16 22 32]
 
 #define VOXEL_OFFSET 0.0
 

--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -59,7 +59,8 @@ void pathTracer(vec2 fragCoord) {
 #endif
 
     float cameraWeight = 1.0;
-    ray r = generatePinholeCameraRay(filmSample);
+    bool lensFlare = false;
+    ray r = generateCameraRay(lambda, filmSample, cameraWeight, lensFlare);
     if (cameraWeight == 0.0) {
         logFilmSample(filmSample, vec3(0.0));
         return;
@@ -74,7 +75,7 @@ void pathTracer(vec2 fragCoord) {
     for (int i = 0;; i++) {
         if (!traceRay(it, voxelOffset, r)) {
 #ifdef SKY_CONTRIBUTION
-            if (i == 0 || (i > 0 && bsdfSample.dirac)) {
+            if ((i == 0 && !lensFlare) || (i > 0 && bsdfSample.dirac)) {
                 ray earthRay = convertToEarthSpace(r);
                 if (intersectSphere(earthRay, sunPosition, sunRadius).x >= 0.0) {
                     float transmittance = estimateTransmittance(earthRay, extinctionBeta);


### PR DESCRIPTION
## Summary
- use the lens-based camera again so ray weights are correct
- reduce light by using a smaller aperture (f/16)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b1c30d17c833088b776151c0dbfbc