### PR TITLE
Fix exposure calculation

### DIFF
--- a/shaders/lib/camera/exposure.glsl
+++ b/shaders/lib/camera/exposure.glsl
@@ -17,8 +17,8 @@ float averageLuminanceToEV100(float avgLum) {
     return log2(avgLum * 100.0 / 12.5);
 }
 
-float cameraSettingsToEV100(float shutterSpeed, float iso) {
-    return log2(shutterSpeed * 100.0 / iso);
+float cameraSettingsToEV100(float shutterSpeed, float iso, float fNumber) {
+    return log2(fNumber * fNumber / shutterSpeed * 100.0 / iso);
 }
 
 float exposureFromEV100(float ev100) {

--- a/shaders/program/main/composite.fsh
+++ b/shaders/program/main/composite.fsh
@@ -55,7 +55,7 @@ void main() {
 #if (EXPOSURE == 0)
     ev100 = averageLuminanceToEV100(renderState.avgLuminance);
 #elif (EXPOSURE == 1)
-    ev100 = cameraSettingsToEV100(float(SHUTTER_SPEED), float(ISO));
+    ev100 = cameraSettingsToEV100(float(SHUTTER_SPEED), float(ISO), renderState.fNumber);
 #endif
     color *= exposureFromEV100(ev100 - float(EV));
 


### PR DESCRIPTION
## Summary
- adjust exposure calculation to consider aperture
- update composite shader to use the new function

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_688b1c30d17c833088b776151c0dbfbc