### PR TITLE
Fix generateCameraRay call

### DIFF
--- a/shaders/program/main/render.csh
+++ b/shaders/program/main/render.csh
@@ -59,7 +59,8 @@ void pathTracer(vec2 fragCoord) {
 #endif
 
     float cameraWeight = 1.0;
-    ray r = generateCameraRay(lambda, filmSample, cameraWeight);
+    bool lensFlare;
+    ray r = generateCameraRay(lambda, filmSample, cameraWeight, lensFlare);
     if (cameraWeight == 0.0) {
         logFilmSample(filmSample, vec3(0.0));
         return;


### PR DESCRIPTION
## Summary
- pass an explicit `lensFlare` output parameter to `generateCameraRay`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b2366af688330b4b2b2bdb2151e05